### PR TITLE
Add Traitor class that doesn't perform validation checks

### DIFF
--- a/src/AbstractTraitor.php
+++ b/src/AbstractTraitor.php
@@ -1,0 +1,145 @@
+<?php
+namespace Icecave\Traitor;
+
+/**
+ * Build a class at run-time.
+ */
+abstract class AbstractTraitor implements TraitorInterface
+{
+    /**
+     * Create a traitor instance.
+     *
+     * @return Traitor
+     */
+    public static function create()
+    {
+        return new static();
+    }
+
+    /**
+     * Make the generated class abstract.
+     *
+     * @param boolean $abstract True to make the class abstract.
+     *
+     * @return Traitor This object.
+     */
+    public function abstract_($abstract = true)
+    {
+        $this->abstract = $abstract;
+
+        return $this;
+    }
+
+    /**
+     * Get the name of the generated class.
+     *
+     * @return string The name of the generated class.
+     */
+    public function name()
+    {
+        $className = $this->generateClassName();
+
+        if (!class_exists($className)) {
+            eval($this->code());
+        }
+
+        return $className;
+    }
+
+    /**
+     * Get a reflector for the generated class.
+     *
+     * @return ReflectionClass The reflector for the generated class.
+     */
+    public function reflector()
+    {
+        return new ReflectionClass(
+            $this->name()
+        );
+    }
+
+    /**
+     * Get an instance of the generated class.
+     *
+     * @param mixed $arguments,... Arguments to pass to the constructor.
+     *
+     * @return object
+     */
+    public function instance()
+    {
+        return $this->instanceArray(
+            func_get_args()
+        );
+    }
+
+    /**
+     * Get an instance of the generated class.
+     *
+     * @param array $arguments,... Arguments to pass to the constructor.
+     *
+     * @return object
+     */
+    public function instanceArray(array $arguments)
+    {
+        return $this
+            ->reflector()
+            ->newInstanceArgs($arguments);
+    }
+
+    /**
+     * Get the generated code.
+     *
+     * @return string The generated code.
+     */
+    public function code()
+    {
+        $indent = '    ';
+        $code = '';
+        if ($this->abstract) {
+            $code .= 'abstract ';
+        }
+        $code .= 'class ' . $this->generateClassName();
+        if ($this->parent) {
+            $code .= ' extends ' . $this->parent;
+        }
+        if ($this->interfaces) {
+            $code .= ' implements' . PHP_EOL;
+            $code .= '    ' . implode(',' . PHP_EOL . $indent, $this->interfaces);
+            $code .= PHP_EOL;
+        }
+        $code .= '{' . PHP_EOL;
+        if ($this->traits) {
+            $code .= '    use ';
+            $code .= implode(',' . PHP_EOL . $indent . $indent, $this->traits) . ';';
+            $code .= PHP_EOL;
+        }
+        $code .= '}' . PHP_EOL;
+
+        return $code;
+    }
+
+    protected function generateClassName()
+    {
+        if ($this->abstract) {
+            $className = 'AbstractTraitorImplementation_';
+        } else {
+            $className = 'TraitorImplementation_';
+        }
+
+        $names = array_merge(
+            array_keys($this->interfaces),
+            array_keys($this->traits)
+        );
+
+        sort($names);
+
+        return $className . md5(
+            $this->parent . implode('', $names)
+        );
+    }
+
+    protected $parent;
+    protected $abstract = false;
+    protected $traits = [];
+    protected $interfaces = [];
+}

--- a/src/AbstractTraitor.php
+++ b/src/AbstractTraitor.php
@@ -1,6 +1,8 @@
 <?php
 namespace Icecave\Traitor;
 
+use ReflectionClass;
+
 /**
  * Build a class at run-time.
  */

--- a/src/TraitorInterface.php
+++ b/src/TraitorInterface.php
@@ -1,0 +1,82 @@
+<?php
+namespace Icecave\Traitor;
+
+interface TraitorInterface
+{
+    /**
+     * Have the generated class extend the given class.
+     *
+     * @param string $class The name of the class to extend.
+     *
+     * @return TraitorInterface This instance.
+     */
+    public function extends_($class);
+
+    /**
+     * Have the generated class implement the given interface(s).
+     *
+     * @param array<string>|string $interfaces     The name of the interface to implement.
+     * @param string               $additional,... Additional interface names.
+     *
+     * @return TraitorInterface This instance.
+     */
+    public function implements_($interfaces);
+
+    /**
+     * Have the generated class use the given trait(s).
+     *
+     * @param array<string>|string $traits         The name of the trait to use.
+     * @param string               $additional,... Additional trait names.
+     *
+     * @return TraitorInterface This instance.
+     */
+    public function use_($traits);
+
+    /**
+     * Make the generated class abstract.
+     *
+     * @param boolean $abstract True to make the class abstract.
+     *
+     * @return TraitorInterface This object.
+     */
+    public function abstract_($abstract = true);
+
+    /**
+     * Get the name of the generated class.
+     *
+     * @return string The name of the generated class.
+     */
+    public function name();
+
+    /**
+     * Get a reflector for the generated class.
+     *
+     * @return ReflectionClass The reflector for the generated class.
+     */
+    public function reflector();
+
+    /**
+     * Get an instance of the generated class.
+     *
+     * @param mixed $arguments,... Arguments to pass to the constructor.
+     *
+     * @return object
+     */
+    public function instance();
+
+    /**
+     * Get an instance of the generated class.
+     *
+     * @param array $arguments,... Arguments to pass to the constructor.
+     *
+     * @return object
+     */
+    public function instanceArray(array $arguments);
+
+    /**
+     * Get the generated code.
+     *
+     * @return string The generated code.
+     */
+    public function code();
+}

--- a/src/TraitorNoChecks.php
+++ b/src/TraitorNoChecks.php
@@ -1,31 +1,20 @@
 <?php
 namespace Icecave\Traitor;
 
-use InvalidArgumentException;
-use ReflectionClass;
-
 /**
  * Build a class at run-time.
  */
-class Traitor extends AbstractTraitor
+class TraitorNoChecks extends AbstractTraitor
 {
     /**
      * Have the generated class extend the given class.
      *
      * @param string $class The name of the class to extend.
      *
-     * @return Traitor This instance.
+     * @return TraitorNoChecks This instance.
      */
     public function extends_($class)
     {
-        $reflector = new ReflectionClass($class);
-
-        if ($reflector->isInterface() || $reflector->isTrait()) {
-            throw new InvalidArgumentException($class . ' is not a class.');
-        } elseif ($reflector->isFinal()) {
-            throw new InvalidArgumentException($class . ' is marked final.');
-        }
-
         $this->parent = $class;
 
         return $this;
@@ -41,19 +30,13 @@ class Traitor extends AbstractTraitor
      */
     public function implements_($interfaces)
     {
-        if (!is_array($interfaces)) {
+        if (is_array($interfaces)) {
+            $interfaces = array_values($interfaces);
+        } else {
             $interfaces = func_get_args();
         }
 
-        foreach ($interfaces as $interface) {
-            $reflector = new ReflectionClass($interface);
-
-            if (!$reflector->isInterface()) {
-                throw new InvalidArgumentException($interface . ' is not an interface.');
-            }
-
-            $this->interfaces[$interface] = $interface;
-        }
+        $this->interfaces = array_merge($this->interfaces, array_combine($interfaces, $interfaces));
 
         return $this;
     }
@@ -68,19 +51,27 @@ class Traitor extends AbstractTraitor
      */
     public function use_($traits)
     {
-        if (!is_array($traits)) {
+        if (is_array($traits)) {
+            $traits = array_values($traits);
+        } else {
             $traits = func_get_args();
         }
 
-        foreach ($traits as $trait) {
-            $reflector = new ReflectionClass($trait);
+        $this->traits = array_merge($this->traits, array_combine($traits, $traits));
 
-            if (!$reflector->isTrait()) {
-                throw new InvalidArgumentException($trait . ' is not a trait.');
-            }
+        return $this;
+    }
 
-            $this->traits[$trait] = $trait;
-        }
+    /**
+     * Make the generated class abstract.
+     *
+     * @param boolean $abstract True to make the class abstract.
+     *
+     * @return Traitor This object.
+     */
+    public function abstract_($abstract = true)
+    {
+        $this->abstract = $abstract;
 
         return $this;
     }

--- a/test/suite/TraitorNoChecksTest.php
+++ b/test/suite/TraitorNoChecksTest.php
@@ -1,0 +1,244 @@
+<?php
+namespace Icecave\Traitor;
+
+use PHPUnit_Framework_TestCase;
+use ReflectionClass;
+
+class TraitorNoChecksTest extends PHPUnit_Framework_TestCase
+{
+    public function testExtends()
+    {
+        $instance = TraitorNoChecks::create()
+            ->extends_('Icecave\Traitor\ParentClass')
+            ->instance();
+
+        $this->assertInstanceOf(
+            'Icecave\Traitor\ParentClass',
+            $instance
+        );
+    }
+
+    public function testImplements()
+    {
+        $instance = TraitorNoChecks::create()
+            ->implements_('Icecave\Traitor\Interface1')
+            ->implements_('Icecave\Traitor\Interface2')
+            ->instance();
+
+        $this->assertInstanceOf(
+            'Icecave\Traitor\Interface1',
+            $instance
+        );
+
+        $this->assertInstanceOf(
+            'Icecave\Traitor\Interface2',
+            $instance
+        );
+    }
+
+    public function testImplementsWithMultipleParameters()
+    {
+        $instance = TraitorNoChecks::create()
+            ->implements_(
+                'Icecave\Traitor\Interface1',
+                'Icecave\Traitor\Interface2'
+            )
+            ->instance();
+
+        $this->assertInstanceOf(
+            'Icecave\Traitor\Interface1',
+            $instance
+        );
+
+        $this->assertInstanceOf(
+            'Icecave\Traitor\Interface2',
+            $instance
+        );
+    }
+
+    public function testImplementsWithArray()
+    {
+        $instance = TraitorNoChecks::create()
+            ->implements_(
+                [
+                    'Icecave\Traitor\Interface1',
+                    'Icecave\Traitor\Interface2',
+                ]
+            )
+            ->instance();
+
+        $this->assertInstanceOf(
+            'Icecave\Traitor\Interface1',
+            $instance
+        );
+
+        $this->assertInstanceOf(
+            'Icecave\Traitor\Interface2',
+            $instance
+        );
+    }
+
+    public function testUse()
+    {
+        $reflector = TraitorNoChecks::create()
+            ->use_('Icecave\Traitor\Trait1')
+            ->use_('Icecave\Traitor\Trait2')
+            ->reflector();
+
+        $this->assertSame(
+            ['Icecave\Traitor\Trait1', 'Icecave\Traitor\Trait2'],
+            array_keys($reflector->getTraits())
+        );
+    }
+
+    public function testUseWithMultipleParameters()
+    {
+        $reflector = TraitorNoChecks::create()
+            ->use_(
+                'Icecave\Traitor\Trait1',
+                'Icecave\Traitor\Trait2'
+            )
+            ->reflector();
+
+        $this->assertSame(
+            ['Icecave\Traitor\Trait1', 'Icecave\Traitor\Trait2'],
+            array_keys($reflector->getTraits())
+        );
+    }
+
+    public function testUseWithArray()
+    {
+        $reflector = TraitorNoChecks::create()
+            ->use_(
+                [
+                    'Icecave\Traitor\Trait1',
+                    'Icecave\Traitor\Trait2',
+                ]
+            )
+            ->reflector();
+
+        $this->assertSame(
+            ['Icecave\Traitor\Trait1', 'Icecave\Traitor\Trait2'],
+            array_keys($reflector->getTraits())
+        );
+    }
+
+    public function testEverything()
+    {
+        $instance = TraitorNoChecks::create()
+            ->extends_('Icecave\Traitor\ParentClass')
+            ->implements_('Icecave\Traitor\Interface1')
+            ->use_('Icecave\Traitor\Trait1')
+            ->instance();
+
+        $this->assertInstanceOf(
+            'Icecave\Traitor\ParentClass',
+            $instance
+        );
+
+        $this->assertInstanceOf(
+            'Icecave\Traitor\Interface1',
+            $instance
+        );
+
+        $this->assertSame(
+            ['Icecave\Traitor\Trait1'],
+            array_keys(
+                (new ReflectionClass($instance))->getTraits()
+            )
+        );
+    }
+
+    public function testEmpty()
+    {
+        $expectedName = 'TraitorImplementation_d41d8cd98f00b204e9800998ecf8427e';
+        $traitor = TraitorNoChecks::create();
+
+        $name = $traitor
+            ->name();
+
+        $this->assertSame(
+            $expectedName,
+            $traitor->name()
+        );
+
+        $reflector = $traitor->reflector();
+
+        $this->assertInstanceOf(
+            'ReflectionClass',
+            $reflector
+        );
+
+        $this->assertSame(
+            $expectedName,
+            $reflector->getName()
+        );
+
+        $this->assertInstanceOf(
+            $expectedName,
+            $traitor->instance()
+        );
+    }
+
+    public function testInstance()
+    {
+        $instance = TraitorNoChecks::create()
+            ->extends_('Icecave\Traitor\ParentClass')
+            ->instance(1, 2, 3);
+
+        $this->assertSame(
+            [1, 2, 3],
+            $instance->arguments
+        );
+    }
+
+    public function testInstanceArray()
+    {
+        $instance = TraitorNoChecks::create()
+            ->extends_('Icecave\Traitor\ParentClass')
+            ->instanceArray([1, 2, 3]);
+
+        $this->assertSame(
+            [1, 2, 3],
+            $instance->arguments
+        );
+    }
+
+    public function testAbstract()
+    {
+        $reflector = TraitorNoChecks::create()
+            ->abstract_()
+            ->reflector();
+
+        $this->assertTrue(
+            $reflector->isAbstract()
+        );
+    }
+
+    public function testCode()
+    {
+        $code = TraitorNoChecks::create()
+            ->extends_('Icecave\Traitor\ParentClass')
+            ->implements_('Icecave\Traitor\Interface1')
+            ->implements_('Icecave\Traitor\Interface2')
+            ->use_('Icecave\Traitor\Trait1')
+            ->use_('Icecave\Traitor\Trait2')
+            ->code();
+
+        $expectedCode = <<<CODE
+class TraitorImplementation_444573daa8f8d04d0e1a9014e4bd4759 extends Icecave\Traitor\ParentClass implements
+    Icecave\Traitor\Interface1,
+    Icecave\Traitor\Interface2
+{
+    use Icecave\Traitor\Trait1,
+        Icecave\Traitor\Trait2;
+}
+
+CODE;
+
+        $this->assertEquals(
+            $expectedCode,
+            $code
+        );
+    }
+}


### PR DESCRIPTION
The rationale behind this is that once you've successfully composed your
class once, it should continue to work, and shouldn't need to check
every interface and trait every time the code is run.

To assist in facilitating this, an interface has been added, and common
code has been abstracted into a parent class. Tests have also been
added.
